### PR TITLE
Added correction for cases when significant pvals are located at ends of thresholded-pvals vector

### DIFF
--- a/functions/AFQ_MultiCompCorrection.m
+++ b/functions/AFQ_MultiCompCorrection.m
@@ -116,7 +116,7 @@ switch(method)
         % Compute cluster size for each permutation
         for ii = 1:nperm
             % Find indices where significant clusters end.
-            % The method based requires significant p-values to be included
+            % The method used requires significant p-values to be included
             % between non-significant p-values. 0 are therefore added at 
             % both ends of the thresholded p-value vector 
             %(for cases when significant p-values are located at its ends)


### PR DESCRIPTION
An error is generated when a cluster is the size of the whole tract for one of the permutation `ii`. This is because in this case `clusEnd = find(pThresh(ii,:) == 0)` and thus `clusSiz = diff(clusEnd)` are empty  and therefore `max(clusSiz)` generates an error.

A possible correction is to set the maximum cluster size to the size of the tract in such a case:
`clusMax(ii) = size(pThresh(ii,:),2)`
