### PR TITLE
Fix for adding a slice to a plot

### DIFF
--- a/3Dmesh/AFQ_AddImageTo3dPlot.m
+++ b/3Dmesh/AFQ_AddImageTo3dPlot.m
@@ -217,6 +217,7 @@ scale = diag(nifti.qto_xyz); scale = scale(1:3);
 % factors for the plane
 oldDim = size(image);
 newDim = oldDim .* scale(find(plane == 0))';
+newDim = abs(newDim); % dimensions can only be positive
 % Resize the image
 image = double(imresize(image,newDim));
 


### PR DESCRIPTION
This fixes an issue where you want to add a slice from an image that has an rxalign matrix with a negative value on the diagonal. Dimensions can only be positive.

